### PR TITLE
(Security) Update to color@3.1.3 to include color-string patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/3rd-Eden/colorspace"
   },
   "dependencies": {
-    "color": "3.0.x",
+    "color": "^3.1.3",
     "text-hex": "1.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Need to incorporate version 1.5.5 of color-string to fix security vulnerability.

See snyk page ([link](https://snyk.io/vuln/npm:color-string))

Best,
Benedikt